### PR TITLE
phantomjs options

### DIFF
--- a/lib/gastly/screenshot.rb
+++ b/lib/gastly/screenshot.rb
@@ -8,12 +8,12 @@ module Gastly
 
     attr_reader :image
     attr_writer :timeout, :browser_width, :browser_height
-    attr_accessor :url, :selector, :cookies, :proxy_host, :proxy_port
+    attr_accessor :url, :selector, :cookies, :proxy_host, :proxy_port, :phantomjs_options
 
     # @param url [String] The full url to the site
     def initialize(url, **kwargs)
       hash = Gastly::Utils::Hash.new(kwargs)
-      hash.assert_valid_keys(:timeout, :browser_width, :browser_height, :selector, :cookies, :proxy_host, :proxy_port)
+      hash.assert_valid_keys(:timeout, :browser_width, :browser_height, :selector, :cookies, :proxy_host, :proxy_port, :phantomjs_options)
 
       @url = url
       @cookies = kwargs.delete(:cookies)
@@ -31,7 +31,7 @@ module Gastly
       Phantomjs.proxy_host = proxy_host if proxy_host
       Phantomjs.proxy_port = proxy_port if proxy_port
 
-      output = Phantomjs.run(proxy_options, SCRIPT_PATH.to_s, *prepared_params)
+      output = Phantomjs.run(options, SCRIPT_PATH.to_s, *prepared_params)
       handle_output(output)
 
       Gastly::Image.new(image)
@@ -45,6 +45,10 @@ module Gastly
     end
 
     private
+
+    def options
+      [proxy_options, phantomjs_options].join(' ').strip
+    end
 
     def proxy_options
       return '' if proxy_host.nil? && proxy_port.nil?

--- a/lib/gastly/version.rb
+++ b/lib/gastly/version.rb
@@ -1,3 +1,3 @@
 module Gastly
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/gastly/screenshot_spec.rb
+++ b/spec/gastly/screenshot_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe Gastly::Screenshot do
   let(:url) { 'http://google.com' }
   let(:params) do
     {
-        selector:       '#hplogo',
-        browser_width:  1280,
-        browser_height: 780,
-        timeout:        1000,
-        cookies:        { user_id: 1, auth_token: 'abcd' },
-        proxy_host:     '10.10.10.1',
-        proxy_port:     '8080'
+      selector:          '#hplogo',
+      browser_width:     1280,
+      browser_height:    780,
+      timeout:           1000,
+      cookies:           { user_id: 1, auth_token: 'abcd' },
+      proxy_host:        '10.10.10.1',
+      proxy_port:        '8080',
+      phantomjs_options: '--load-images=false'
     }
   end
   subject { Gastly::Screenshot.new(url) }
@@ -47,7 +48,7 @@ RSpec.describe Gastly::Screenshot do
       screenshot = Gastly::Screenshot.new(url, params)
       cookies = params[:cookies].map { |key, value| "#{key}=#{value}" }.join(',')
       args = [
-        "--proxy=#{params[:proxy_host]}:#{params[:proxy_port]}",
+        "--proxy=#{params[:proxy_host]}:#{params[:proxy_port]} #{params[:phantomjs_options]}",
         Gastly::Screenshot::SCRIPT_PATH,
         "url=#{url}",
         "timeout=#{params[:timeout]}",


### PR DESCRIPTION
Added ability to send CLI options to PhantomJS
E.g. Gastly.screenshot(url, phantomjs_options: '--ignore-ssl-
errors=true').capture